### PR TITLE
RadX uses the system libraries when possible.

### DIFF
--- a/provision_scripts/install_radx.sh
+++ b/provision_scripts/install_radx.sh
@@ -2,46 +2,38 @@
 set -x
 
 # Vagrant provision script for installing Radx
+# This script installs as many dependencies using the system packages as
+# possible. In addition no packages are expected to be installed prior to
+# running this script
 
 # Set version here
 #   see available versions here: https://www.eol.ucar.edu/software/radx
 VERSION=20141011
 
-
 # Install Radx depencies
 # see http://www.ral.ucar.edu/projects/titan/docs/radial_formats/README
 
-##gcc 4.3+ compiler --> already aboard the VM
-##g++ 4.3+ compiler --> already aboard the VM
-##gfortran compiler --> already aboard the VM
-
-sudo apt-get install -qq tcsh
-##perl shell --> already aboard the VM
-
-# for fftw3-devel
-sudo apt-get install -qq libfftw3-dev
-#for  bzip2-devel
+# gcc installed on the base VM
+sudo apt-get install -qq g++
+sudo apt-get install -qq libhdf5-dev netcdf-bin libnetcdf-dev 
+sudo apt-get install -qq libudunits2-dev
 sudo apt-get install -qq libbz2-dev
-# for zlib-devel
-sudo apt-get install -qq zlib1g-dev
-# for expat-devel
-sudo apt-get install -qq expat
+sudo apt-get install -qq libfftw3-dev
+
+
+# UNKNOWN
 
 # Install Radx from source
 cd ~
 mkdir tmp
 cd tmp
-wget https://www.eol.ucar.edu/system/files/software/radx/all-oss/radx-$VERSION.src_.tgz -O radx-$VERSION.src_.tgz
+wget -q https://www.eol.ucar.edu/system/files/software/radx/all-oss/radx-$VERSION.src_.tgz -O radx-$VERSION.src_.tgz
 
 tar xfz radx-$VERSION.src_.tgz
 
 rm radx-$VERSION.src_.tgz 
 
 cd radx-$VERSION.src
-
-# build HDF5, NetCDF and udunits2
-chmod +x build_netcdf
-sudo ./build_netcdf
 
 # build Radx
 chmod +x build_radx


### PR DESCRIPTION
This edits the RadX provision script so that the system netcdf, hdf5, and udunits are used when compiling RadX.   RadX still adds significantly to the size of the VM even with this change as the binaries and libraries are quite large (change to last line to `sudo ./build_radx /tmp/radx` and look in the /tmp/radx directory for details).