### PR TITLE
Fixing link to localhost in documentation.

### DIFF
--- a/doc/source/build.rst
+++ b/doc/source/build.rst
@@ -38,7 +38,7 @@ Use
 ``$ ./start_notebook.sh`` 
 
 to start the IPython notebook server running on the VM. From the host visit 
-http://127.0.0.0:8888/tree to interact with the server.
+http://127.0.0.1:8888/tree to interact with the server.
 
 The VM can be suspeded using ``vagrant suspend`` or stopped using
 ``vagrant halt``.  The VM can also be paused from the VirtualBox GUI.

--- a/doc/source/courses.rst
+++ b/doc/source/courses.rst
@@ -11,7 +11,7 @@ Once you have logged into the VM, run the command
 
 ``$ ./start_notebook.sh``.
 
-Then open a browser window on your host machine and navigate to http://127.0.0.0:8888/tree. 
+Then open a browser window on your host machine and navigate to http://127.0.0.1:8888/tree. 
 From here, you can browse through the available IPython notebooks.
 
 You can also access the course repositories directly:

--- a/doc/source/features.rst
+++ b/doc/source/features.rst
@@ -28,7 +28,7 @@ root directory, run
 
 ``$ ./start_notebook.sh``
 
-Open a browser on your host machine and navigate to http://127.0.0.0:8888/tree.
+Open a browser on your host machine and navigate to http://127.0.0.1:8888/tree.
 
 See :doc:`quickstart` for further infos.
 

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -36,7 +36,7 @@ Once you have logged into the VM, run the command
 
 ``$ ./start_notebook.sh``.
 
-Then open a browser window on your host machine and navigate to http://127.0.0.0:8888/tree.
+Then open a browser window on your host machine and navigate to http://127.0.0.1:8888/tree.
 
 In order to get started, you can choose from a selection of course notebooks. 
 See :doc:`here <courses>` for more details on available courses.


### PR DESCRIPTION
I don't know how we overlooked this until now, but local host was always linked as 127.0.0.0 instead of 127.0.0.1.