### PR TITLE
FIX: Make sidebars appear on each page.

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -148,11 +148,11 @@ html_static_path = ['_static']
 #html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-#html_sidebars = {}
-html_sidebars = {
-   '**': ['globaltoc.html', 'sourcelink.html', 'searchbox.html'],
-   'using/windows': ['windowssidebar.html', 'searchbox.html'],
-}
+html_sidebars = {}
+#html_sidebars = {
+#   '**': ['globaltoc.html', 'sourcelink.html', 'searchbox.html'],
+#   'using/windows': ['windowssidebar.html', 'searchbox.html'],
+#}
 #html_sidebars = {
 #    '**': ['localtoc.html',]
 #}

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -26,7 +26,6 @@ Quicklinks
 
 .. toctree::
    :maxdepth: 1
-   :hidden:
    
    background
    features


### PR DESCRIPTION
It was time for an update of the html docs.

With newer Sphinx versions, though, it becomes harder to control the sidebar
behaviour without touching the theme itself. I had to remove the
`hidden` directive for the toctree and tweak the conf file in order to
make the TOC appear on each page. Cost of this: TOC also appears at the
bottom of the index page. Maybe we find a better way someday.

I already updated the html docs, although this PR is not accepted yet. Hope that's fine.