### PR TITLE
Affiliation change, and minor privisioning issues to wradlib and BALTRAD

### DIFF
--- a/doc/source/team.rst
+++ b/doc/source/team.rst
@@ -10,7 +10,7 @@ Team BALTRAD
 
 Anders Henja (HENJAB, Sweden)
 
-Daniel B. Michelson (Swedish Meteorological and Hydrological Institute, Sweden)
+Daniel B. Michelson (Environment Canada, Canada)
 
 
 Team Py-ART

--- a/doc/source/team.rst
+++ b/doc/source/team.rst
@@ -10,7 +10,7 @@ Team BALTRAD
 
 Anders Henja (HENJAB, Sweden)
 
-Daniel B. Michelson (Environment Canada, Canada)
+Daniel B. Michelson (Environment and Climate Change Canada)
 
 
 Team Py-ART

--- a/provision_scripts/install_baltrad_rave_gmap.sh
+++ b/provision_scripts/install_baltrad_rave_gmap.sh
@@ -4,6 +4,7 @@ set -x
 # Vagrant provision script for installing BALTRAD GoogleMapsPlugin component
 
 # dependencies
+sudo apt-get install -qq libfreetype6-dev
 sudo apt-get install -qq apache2
 sudo apt-get install -qq php5
 sudo apt-get install -qq libapache2-mod-php5
@@ -21,6 +22,7 @@ cd tmp
 wget --no-check-certificate http://git.baltrad.eu/blt_dependencies/Imaging-1.1.7.tar.gz .
 tar xvzf Imaging-1.1.7.tar.gz
 cd Imaging-1.1.7
+sed -i -e 's/#include <freetype\//#include <freetype2\//g' _imagingft.c
 sudo cp /vagrant/vendor/setup.py.Imaging-1.1.7-tweaked setup.py
 sudo python setup.py install
 

--- a/provision_scripts/install_wradlib.sh
+++ b/provision_scripts/install_wradlib.sh
@@ -6,7 +6,7 @@ set -x
 # Install wradlib depencies
 sudo pip install numpy 
 sudo apt-get install -qq libfontconfig1 python-gdal python-h5py
-#sudo pip install xmltodict
+sudo pip install xmltodict
 #sudo pip install importlib
 
 # Install wradlib from source


### PR DESCRIPTION
wradlib's optional dependency xmltodict is useful for reading Rainbow5 data.
BALTRAD's GoogleMapsPlugin needs font support that was lacking and needed to be tweaked.