### PR TITLE
Pip upgrade to latest zmq

### DIFF
--- a/provision_scripts/install_scipy_stack.sh
+++ b/provision_scripts/install_scipy_stack.sh
@@ -6,6 +6,7 @@ sudo apt-get update -qq
 sudo apt-get install -qq python-pip python-dev
 sudo apt-get install -qq python-numpy python-scipy python-matplotlib cython
 sudo apt-get install -qq python-zmq python-jinja2
+sudo pip install --upgrade zmq
 sudo pip install jupyter
 sudo apt-get install -qq libhdf5-dev netcdf-bin libnetcdf-dev 
 sudo pip install netcdf4


### PR DESCRIPTION
The version of ZMQ installed by default has an issue with 32-bit builds.
The latest version has fixed this issue.

closes #29