### PR TITLE
Some minor changes in the docs and a customization of the 32bit built.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,6 +27,12 @@ Vagrant.configure("2") do |config|
   #config.vm.provider "virtualbox" do |vb|
   #  vb.customize ["modifyvm", :id, "--hwvirtex", "off"]
   #  vb.customize ["modifyvm", :id, "--memory", "2048"]
+  #  ## You might need to uncomment the following if built times out after "default: SSH auth method: private key"
+  #  ## Change network card to PCnet-FAST III 
+  #  ## For NAT adapter
+  #  #vb.customize ["modifyvm", :id, "--nictype1", "Am79C973"]
+  #  ## For host-only adapter
+  #  #vb.customize ["modifyvm", :id, "--nictype2", "Am79C973"]
   #end 
 
   # forward the default IPython port

--- a/doc/source/build.rst
+++ b/doc/source/build.rst
@@ -70,7 +70,7 @@ For the latter, choose the *File* menu, then *Export Appliance*. Writing the ova
 
 **32-bit image**
 
-Edit ``Vagrantfile``: comment out lines 11-20, uncomment 24-30
+Edit ``Vagrantfile``: comment out lines 11-20, uncomment 24-36
 
 ``$ vagrant up``
 

--- a/doc/source/downloads.rst
+++ b/doc/source/downloads.rst
@@ -4,7 +4,7 @@ Downloads
 Readily-built VM images
 -----------------------
 
-Download readily-built VM images `here <http://sourceforge.net/projects/openradarvm/files/openradarvm/>`_.
+Download readily-built VM images `here <http://tinyurl.com/OpenRadarVM>`_.
 
 Make sure you select the correct image for your system (32-bit or 64-bit built).
 

--- a/doc/source/knownissues.rst
+++ b/doc/source/knownissues.rst
@@ -9,7 +9,7 @@ keyboard mapping is weird. One way to fix it is to install ``console data``:
 
 If you're logged in the VM, call 
 
-``$apt-get install console-data`` 
+``$sudo apt-get install console-data`` 
 
 from the shell. During the installation process, you will be able to choose an appropriate keyboard layout.
 


### PR DESCRIPTION
- http://tinyurl.com/OpenRadarVM as temporary download address
- installation of console-data (fixes keyboard layout) requires `sudo`
- added a couple of lines to the 32bit built block in the Vagrantfile which need to be uncommented in case the built process times out during authentication.