### PR TITLE
MAINT: Changed version of pyart and notebook location.

### DIFF
--- a/provision_scripts/install_pyart.sh
+++ b/provision_scripts/install_pyart.sh
@@ -1,20 +1,20 @@
 #!/usr/bin/env bash
 set -x
 
-# Vagrant provision script for installing Py-ART
+# Vagrant provision script for installing Py-ART.
 
 # dependencies
 ##sudo apt-get install -qq libfontconfig1 --> moved to install_common.sh 
 ##sudo apt-get install -qq gfortran               # for Steiner echo-class --> moved to install_common.sh
 sudo apt-get install -qq python-mpltoolkits.basemap
 
-# Install Py-ART version 1.9.0 from source to system Python
+# Install Py-ART version 1.9.1 from source to system Python.
 cd ~
 mkdir tmp
 cd tmp
-wget https://github.com/ARM-DOE/pyart/releases/download/v1.9.0-picasso/arm_pyart-1.9.0.tar.gz
-tar xf arm_pyart-1.9.0.tar.gz
-cd arm_pyart-1.9.0/
+wget https://github.com/ARM-DOE/pyart/releases/download/v1.9.1-picasso/arm_pyart-1.9.1.tar.gz
+tar xf arm_pyart-1.9.1.tar.gz
+cd arm_pyart-1.9.1/
 sudo python setup.py install
 
 # and install to conda env

--- a/provision_scripts/install_pyart_notebooks.sh
+++ b/provision_scripts/install_pyart_notebooks.sh
@@ -7,8 +7,8 @@ cd ~
 # Install git and zip/unzip just in case.
 sudo apt-get install -qq git
 sudo apt-get install -qq zip unzip
-git clone https://github.com/openradar/AMS-Short-Course-on-Open-Source-Radar-Software.git pyart_short_course
+git clone https://github.com/EVS-ATMOS/pyart-notebooks.git pyart_short_course
 
-# Retrieve the data for the Py-ART course. Adds ~1 GB to the VM size.
+# Retrieve the data for the Py-ART course. Adds ~0.7 GB to the VM size.
 cd pyart_short_course/data
 ./provision_data.sh


### PR DESCRIPTION
New version of pyart 1.9.1 fixes netcdftime/cftime import issue. Notebooks from ERAD course are now found in pyart-notebooks repository. The script now clones this repository.