### PR TITLE
BALTRAD to Python3 and conda

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 This projects creates a Linux Virtual Machine image (VM) with a number
 of open source weather radar software packages 
-(BALTRAD, Py-ART, Radx, RSL, and wradlib) which can be run using VirtualBox on a
+(BALTRAD, Py-ART, PyTMatrix, Radx, RSL, and wradlib) which can be run using VirtualBox on a
 number of host OSes.
 
 The creation of this VM has been tested on Ubuntu 12.04 and
 Mac OS X 10.9 hosts running vagrant 1.5.4.  Other host should
 be supported if a recent version of vagrant (1.3+) and VirtualBox 
-can be installed.
+can be installed. Subsequent versions of this project have used Debian Linux
+and subsequent versions of both vagrant and VirtualBox.
 
 ## Requirements ##
 
@@ -29,10 +30,10 @@ subsequent uses of `vagrant up` should complete much quicker
 The VM can be access from the host computer using the command
 `vagrant ssh`.  Launching the VirtualBox gui will show the VM running.
 
-A IPython notebook server can be run from the VM which is
+A JuPyter notebook server can be run from the VM which is
 accessible from the host machine.  Use the command `vagrant ssh`
 to ssh into the running VM.  Then use `./start_notebook.sh` to start
-the IPython notebook server running on the VM.  From the host visit 
+the JuPyter notebook server running on the VM.  From the host visit 
 [127.0.0.1:8888](http://127.0.0.1:8888) to interact with the 
 server.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -92,6 +92,6 @@ Vagrant.configure("2") do |config|
   config.vm.provision :shell, :privileged => false, :path => "provision_scripts/copy_guest_scripts.sh"
 
   # cleanup
-##  config.vm.provision :shell, :privileged => false, :path => "provision_scripts/cleanup.sh" 
+  config.vm.provision :shell, :privileged => false, :path => "provision_scripts/cleanup.sh" 
 
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,11 +9,12 @@ Vagrant.configure("2") do |config|
   end
   
   config.vm.box = "debian/stretch64"
+#  config.vm.box_version = "9.3.0"
   config.vm.box_url = "https://vagrantcloud.com/debian/boxes/stretch64/versions/9.2.0/providers/virtualbox.box"
   # The .box file can also be specified as a file on the local machine,
   # comment the above config.vm.box line, uncomment and edit the next line.
-  #config.vm.box_url = "file:///home/.../trusty-server-cloudimg-amd64-vagrant-disk1.box"
-  
+#  config.vm.box_url = "file:///Users/baltrad/Desktop/stretch64_9.2.0_virtualbox.box"
+  config.ssh.forward_x11 = true
   # configure VM instance
   config.vm.provider "virtualbox" do |vb|
     vb.customize ["modifyvm", :id, "--memory", "2048"]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -48,10 +48,10 @@ Vagrant.configure("2") do |config|
   # Requirements not related to Python or a specific package
   config.vm.provision :shell, :privileged => false, :path => "provision_scripts/install_common.sh"
   
-  # Python environment (system, not conda)
-  config.vm.provision :shell, :privileged => false, :path => "provision_scripts/install_scipy_stack.sh"
+  # Python2 environment (system, not conda)
+#retired#  config.vm.provision :shell, :privileged => false, :path => "provision_scripts/install_scipy_stack.sh"
   
-  # Python environment (conda)
+  # Python3 environment (conda)
   config.vm.provision :shell, :privileged => false, :path => "provision_scripts/install_conda.sh"
   
   # wradlib to conda
@@ -62,20 +62,20 @@ Vagrant.configure("2") do |config|
   config.vm.provision :shell, :privileged => false, :path => "provision_scripts/install_pyart_notebooks.sh"
   
   # BALTRAD
-  config.vm.provision :shell, :privileged => false, :path => "provision_scripts/install_baltrad_common.sh"
+#retired#  config.vm.provision :shell, :privileged => false, :path => "provision_scripts/install_baltrad_common.sh"
   config.vm.provision :shell, :privileged => false, :path => "provision_scripts/install_baltrad_hlhdf.sh"
-  config.vm.provision :shell, :privileged => false, :path => "provision_scripts/install_baltrad_bbufr.sh"
+#retired#  config.vm.provision :shell, :privileged => false, :path => "provision_scripts/install_baltrad_bbufr.sh"
   config.vm.provision :shell, :privileged => false, :path => "provision_scripts/install_baltrad_rave.sh"  
   config.vm.provision :shell, :privileged => false, :path => "provision_scripts/install_baltrad_beamb.sh"
   config.vm.provision :shell, :privileged => false, :path => "provision_scripts/install_baltrad_bropo.sh"
   config.vm.provision :shell, :privileged => false, :path => "provision_scripts/install_baltrad_rave_gmap.sh"
   config.vm.provision :shell, :privileged => false, :path => "provision_scripts/install_baltrad_wrwp.sh"
-  config.vm.provision :shell, :privileged => false, :path => "provision_scripts/install_baltrad_finalize.sh"
+#retired#  config.vm.provision :shell, :privileged => false, :path => "provision_scripts/install_baltrad_finalize.sh"
   config.vm.provision :shell, :privileged => false, :path => "provision_scripts/install_baltrad_short_course.sh"
   
   # Radx
-  config.vm.provision :shell, :privileged => false, :path => "provision_scripts/install_radx.sh"
-  config.vm.provision :shell, :privileged => false, :path => "provision_scripts/install_radx_short_course.sh"
+## config.vm.provision :shell, :privileged => false, :path => "provision_scripts/install_radx.sh"
+##  config.vm.provision :shell, :privileged => false, :path => "provision_scripts/install_radx_short_course.sh"
 
   # PyTMatrix to system Python and conda
   config.vm.provision :shell, :privileged => false, :path => "provision_scripts/install_pytmatrix.sh"
@@ -92,6 +92,6 @@ Vagrant.configure("2") do |config|
   config.vm.provision :shell, :privileged => false, :path => "provision_scripts/copy_guest_scripts.sh"
 
   # cleanup
-  config.vm.provision :shell, :privileged => false, :path => "provision_scripts/cleanup.sh" 
+##  config.vm.provision :shell, :privileged => false, :path => "provision_scripts/cleanup.sh" 
 
 end

--- a/guest_scripts/start_notebook.sh
+++ b/guest_scripts/start_notebook.sh
@@ -2,11 +2,5 @@
 
 cd ~
 
-if [ $# -eq 1 ]
-    then echo "Using conda environment $1" && \
-            source $CONDA_DIR/bin/activate $1 && \
-            jupyter notebook --no-browser --ip=10.0.2.15
-    else echo "Using system Python" && \
-            ipython notebook --no-browser --ip=10.0.2.15
-
-fi
+source $CONDA_DIR/bin/activate $CONDA_DIR/envs/$RADARENV/ && \
+    jupyter notebook --no-browser --ip=10.0.2.15

--- a/provision_scripts/install_baltrad_beamb.sh
+++ b/provision_scripts/install_baltrad_beamb.sh
@@ -4,7 +4,7 @@ set -x
 # Vagrant provision script for installing BALTRAD beamb component
 
 # install dependencies
-export LD_LIBRARY_PATH=/opt/baltrad/hlhdf/lib:/opt/baltrad/rave/lib
+export LD_LIBRARY_PATH=/home/vagrant/miniconda/envs/openradar/lib:/home/vagrant/miniconda/envs/openradar/hlhdf/lib:/home/vagrant/miniconda/envs/openradar/rave/lib
 
 # install beamb from source
 cd ~
@@ -14,19 +14,23 @@ fi
 cd tmp
 git clone --depth=1 git://git.baltrad.eu/beamb.git
 cd beamb/
-./configure --prefix=/opt/baltrad/beamb --with-rave=/opt/baltrad/rave
+
+source $CONDA_DIR/bin/activate $CONDA_DIR/envs/$RADARENV/
+
+./configure --prefix=/home/vagrant/miniconda/envs/openradar/beamb --with-rave=/home/vagrant/miniconda/envs/openradar/rave
 make
 make test
 make install
+echo /home/vagrant/miniconda/envs/openradar/beamb/share/beamb/pybeamb > /home/vagrant/miniconda/lib/python3.6/site-packages/beamb.pth
 
 grep -l beamb ~/.bashrc
 if [ $? == 1 ] ;
 then 
-echo "export PATH=\"\$PATH:/opt/baltrad/beamb/bin\"" >> ~/.bashrc;
-echo "export LD_LIBRARY_PATH=\"\$LD_LIBRARY_PATH:/opt/baltrad/beamb/lib\"" >> ~/.bashrc;
+echo "export PATH=\"\$PATH:/home/vagrant/miniconda/envs/openradar/beamb/bin\"" >> ~/.bashrc;
+echo "export LD_LIBRARY_PATH=\"\$LD_LIBRARY_PATH:/home/vagrant/miniconda/envs/openradar/beamb/lib\"" >> ~/.bashrc;
 fi
-grep -l beamb /opt/baltrad/rave/etc/rave_pgf_quality_registry.xml
+grep -l beamb /home/vagrant/miniconda/envs/openradar/rave/etc/rave_pgf_quality_registry.xml
 if [ $? == 1 ] ;
 then 
-sed -i 's/<\/rave-pgf-quality-registry>/  <quality-plugin name="beamb" module="beamb_quality_plugin" class="beamb_quality_plugin"\/>\n<\/rave-pgf-quality-registry>/g' /opt/baltrad/rave/etc/rave_pgf_quality_registry.xml;
+sed -i 's/<\/rave-pgf-quality-registry>/  <quality-plugin name="beamb" module="beamb_quality_plugin" class="beamb_quality_plugin"\/>\n<\/rave-pgf-quality-registry>/g' /home/vagrant/miniconda/envs/openradar/rave/etc/rave_pgf_quality_registry.xml;
 fi

--- a/provision_scripts/install_baltrad_bropo.sh
+++ b/provision_scripts/install_baltrad_bropo.sh
@@ -4,8 +4,8 @@ set -x
 # Vagrant provision script for installing BALTRAD bropo component
 
 # dependencies
-sudo apt-get install -qq libpng-dev
-export LD_LIBRARY_PATH=/opt/baltrad/hlhdf/lib:/opt/baltrad/rave/lib
+#sudo apt-get install -qq libpng-dev
+export LD_LIBRARY_PATH=/home/vagrant/miniconda/envs/openradar/lib:/home/vagrant/miniconda/envs/openradar/hlhdf/lib:/home/vagrant/miniconda/envs/openradar/rave/lib
 
 # install bropo from source
 cd ~
@@ -15,7 +15,10 @@ fi
 cd tmp
 git clone --depth 1 git://git.baltrad.eu/bropo.git
 cd bropo/
-./configure --prefix=/opt/baltrad/bropo --with-rave=/opt/baltrad/rave
+
+source $CONDA_DIR/bin/activate $CONDA_DIR/envs/$RADARENV/
+
+./configure --prefix=/home/vagrant/miniconda/envs/openradar/bropo --with-rave=/home/vagrant/miniconda/envs/openradar/rave --with-png=/home/vagrant/miniconda/envs/openradar
 make
 make test
 make install
@@ -23,10 +26,10 @@ make install
 grep -l bropo ~/.bashrc
 if [ $? == 1 ] ;
 then 
-echo "export PATH=\"\$PATH:/opt/baltrad/bropo/bin\"" >> ~/.bashrc;
-echo "export LD_LIBRARY_PATH=\"\$LD_LIBRARY_PATH:/opt/baltrad/bropo/lib\"" >> ~/.bashrc;
+echo "export PATH=\"\$PATH:/home/vagrant/miniconda/envs/openradar/bropo/bin\"" >> ~/.bashrc;
+echo "export LD_LIBRARY_PATH=\"\$LD_LIBRARY_PATH:/home/vagrant/miniconda/envs/openradar/bropo/lib\"" >> ~/.bashrc;
 fi
-grep -l ropo_quality_plugin /opt/baltrad/rave/etc/rave_pgf_quality_registry.xml
+grep -l ropo_quality_plugin /home/vagrant/miniconda/envs/openradar/rave/etc/rave_pgf_quality_registry.xml
 if [ $? == 1 ] ;
-then sed -i 's/<\/rave-pgf-quality-registry>/  <quality-plugin name="ropo" module="ropo_quality_plugin" class="ropo_quality_plugin"\/>\n<\/rave-pgf-quality-registry>/g' /opt/baltrad/rave/etc/rave_pgf_quality_registry.xml;
+then sed -i 's/<\/rave-pgf-quality-registry>/  <quality-plugin name="ropo" module="ropo_quality_plugin" class="ropo_quality_plugin"\/>\n<\/rave-pgf-quality-registry>/g' /home/vagrant/miniconda/envs/openradar/rave/etc/rave_pgf_quality_registry.xml;
 fi

--- a/provision_scripts/install_baltrad_common.sh
+++ b/provision_scripts/install_baltrad_common.sh
@@ -3,6 +3,14 @@ set -x
 
 # Global BALTRAD setup
 ##sudo apt-get install -qq git -> moved to install_common.sh
+sudo apt-get install -qq python3-dev
+sudo apt-get install -qq libpython3.5-dbg
+sudo apt-get install -qq python3.5-numpy
+sudo apt-get install -qq python3-pip
+sudo python3 -m pip install --upgrade pip
+sudo python3 -m pip install jupyter
+sudo pip3 install matplotlib
+
 sudo mkdir /opt/baltrad
 sudo chown vagrant:vagrant /opt/baltrad
 

--- a/provision_scripts/install_baltrad_hlhdf.sh
+++ b/provision_scripts/install_baltrad_hlhdf.sh
@@ -26,10 +26,11 @@ cd hlhdf/
 # for Ubuntu 14.04, the location is /usr/lib/x86_64-linux-gnu/
 # for Ubuntu 16.04, the location is /usr/lib/x86_64-linux-gnu/hdf5/serial/ (might be different on your system)
 
-./configure --prefix=/opt/baltrad/hlhdf --with-hdf5=/usr/include/hdf5/serial,/usr/lib/x86_64-linux-gnu/hdf5/serial
+./configure --prefix=/opt/baltrad/hlhdf --with-hdf5=/usr/include/hdf5/serial,/usr/lib/x86_64-linux-gnu/hdf5/serial --enable-py3support
 make
 make test
-make install
+sudo make install
+sudo mv /opt/baltrad/hlhdf/hlhdf.pth /usr/lib/python3/dist-packages/hlhdf.pth
 
 grep -l hlhdf ~/.bashrc
 if [ $? == 1 ] ;

--- a/provision_scripts/install_baltrad_hlhdf.sh
+++ b/provision_scripts/install_baltrad_hlhdf.sh
@@ -3,7 +3,7 @@ set -x
 
 # Vagrant provision script for installing BALTRAD HL-HDF component
 
-# Install hlhdf depencies
+# Install hlhdf depencies + removed because they are now in conda
 
 # Install hlhdf from source
 cd ~

--- a/provision_scripts/install_baltrad_hlhdf.sh
+++ b/provision_scripts/install_baltrad_hlhdf.sh
@@ -13,31 +13,20 @@ fi
 cd tmp
 git clone --depth=1 git://git.baltrad.eu/hlhdf.git
 cd hlhdf/
-# configure hlhdf
-# we need to point to the location of the hdf5 headers and binaries
-# find out where the headers live on your system with
-# $ locate hdf5.h
-# for Ubuntu 14.04, the location is /usr/include/
-# for Ubuntu 16.04, the location is /usr/include/hdf5/serial (might be different on your system)
-#
-# and the same for the binaries:
-# $ locate libhdf5.a
-# $ locate libhdf5.so
-# for Ubuntu 14.04, the location is /usr/lib/x86_64-linux-gnu/
-# for Ubuntu 16.04, the location is /usr/lib/x86_64-linux-gnu/hdf5/serial/ (might be different on your system)
 
-./configure --prefix=/opt/baltrad/hlhdf --with-hdf5=/usr/include/hdf5/serial,/usr/lib/x86_64-linux-gnu/hdf5/serial --enable-py3support
+source $CONDA_DIR/bin/activate $CONDA_DIR/envs/$RADARENV/ && \
+    $CONDA_DIR/bin/conda install -c conda-forge --yes make
+
+# Below is for Debian 9.2.0 and its conda with Python 3.6
+./configure --prefix=/home/vagrant/miniconda/envs/openradar/hlhdf --with-hdf5=/home/vagrant/miniconda/envs/openradar/include,/home/vagrant/miniconda/envs/openradar/lib --enable-py3support --with-py3bin=/home/vagrant/miniconda/envs/openradar/bin/python3 --with-numpy=/home/vagrant/miniconda/envs/openradar/lib/python3.6/site-packages/numpy/core/include/numpy/
 make
 make test
-sudo make install
-sudo mv /opt/baltrad/hlhdf/hlhdf.pth /usr/lib/python3/dist-packages/hlhdf.pth
+make install
+mv /home/vagrant/miniconda/envs/openradar/hlhdf/hlhdf.pth /home/vagrant/miniconda/envs/openradar/lib/python3.6/site-packages/.
 
 grep -l hlhdf ~/.bashrc
 if [ $? == 1 ] ;
 then 
-echo "export PATH=\"\$PATH:/opt/baltrad/hlhdf/bin\"" >> ~/.bashrc;
-echo "export LD_LIBRARY_PATH=\"\$LD_LIBRARY_PATH:/opt/baltrad/hlhdf/lib\"" >> ~/.bashrc;
+echo "export PATH=\"\$PATH:/home/vagrant/miniconda/envs/openradar/hlhdf/bin\"" >> ~/.bashrc
+echo "export LD_LIBRARY_PATH=\"\$LD_LIBRARY_PATH:/home/vagrant/miniconda/envs/openradar/lib:/home/vagrant/miniconda/envs/openradar/hlhdf/lib\"" >> ~/.bashrc;
 fi
-
-# HACK, I believe this should be done during make install
-sudo cp /opt/baltrad/hlhdf/hlhdf.pth /usr/lib/python2.7/dist-packages/

--- a/provision_scripts/install_baltrad_rave.sh
+++ b/provision_scripts/install_baltrad_rave.sh
@@ -6,12 +6,12 @@ set -x
 # Install RAVE depencies
 # Moved installation for some of these dependencies to install_baltrad_bbufr.sh
 #sudo apt-get install -qq libproj0
-#sudo apt-get install -qq proj-bin
-#sudo apt-get install -qq libproj-dev
-sudo apt-get install -qq expat
-sudo apt-get install -qq libexpat-dev
+sudo apt-get install -qq proj-bin
+sudo apt-get install -qq libproj-dev
+#sudo apt-get install -qq expat
+#sudo apt-get install -qq libexpat-dev
 
-export LD_LIBRARY_PATH=/opt/baltrad/hlhdf/lib
+export LD_LIBRARY_PATH=/home/vagrant/miniconda/envs/openradar/hlhdf/lib
 
 # Install RAVE from source
 cd ~
@@ -19,19 +19,28 @@ if ! [ -d tmp ]; then
 mkdir tmp
 fi
 cd tmp
-git clone --depth=1 git://git.baltrad.eu/rave.git
-cd rave
+git clone --depth=1 git://git.baltrad.eu/rave-py3.git
+cd rave-py3
 sed -i -e 's/import jprops/#import jprops/g' Lib/rave_bdb.py
 sed -i -e 's/import jprops/#import jprops/g' Lib/rave_dom_db.py
+sed -i -e 's/import jprops/#import jprops/g' Lib/rave_bdb.py
+sed -i -e 's/from baltrad.bdbclient/#from baltrad.bdbclient/g' Lib/rave_bdb.py
 sed -i -e 's/from keyczar import keyczar/#from keyczar import keyczar/g' Lib/BaltradFrame.py
-./configure --prefix=/opt/baltrad/rave --with-hlhdf=/opt/baltrad/hlhdf --with-proj=/usr/include,/usr/lib/x86_64-linux-gnu --with-expat=/usr/include,/usr/lib/x86_64-linux-gnu --with-numpy=/usr/lib/python3/dist-packages/numpy/core/include/numpy/ --with-netcdf=/usr/include,/usr/lib/x86_64-linux-gnu --enable-py3support
+cp -p /vagrant/vendor/fix_shebang.sh bin/.  # Copies in path to Python for conda
+
+source $CONDA_DIR/bin/activate $CONDA_DIR/envs/$RADARENV/
+
+./configure --prefix=/home/vagrant/miniconda/envs/openradar/rave --with-hlhdf=/home/vagrant/miniconda/envs/openradar/hlhdf --with-proj=/usr/include,/usr/lib/x86_64-linux-gnu --with-expat=/home/vagrant/miniconda/envs/openradar/include,/home/vagrant/miniconda/envs/openradar/lib --with-numpy=/home/vagrant/miniconda/envs/openradar/lib/python3.6/site-packages/numpy/core/include/numpy/ --with-netcdf=/home/vagrant/miniconda/envs/openradar/include,/home/vagrant/miniconda/envs/openradar/lib --enable-py3support --with-py3bin=/home/vagrant/miniconda/envs/openradar/bin/python --with-py3bin-config=/home/vagrant/miniconda/envs/openradar/bin/python3-config --with-python-makefile=/home/vagrant/miniconda/envs/openradar/lib/python3.6/config-3.6m-x86_64-linux-gnu/Makefile
 make
 make test
-sudo make install
+make install
+# Copy files that need special (temporary) monkeying to transition to Py3
+cp -r /vagrant/vendor/opt/baltrad/rave/Lib/* /home/vagrant/miniconda/envs/openradar/rave/Lib/
 
 grep -l rave ~/.bashrc
 if [ $? == 1 ] ;
-then 
-echo "export PATH=\"\$PATH:/opt/baltrad/rave/bin\"" >> ~/.bashrc;
-echo "export LD_LIBRARY_PATH=\"\$LD_LIBRARY_PATH:/opt/baltrad/rave/lib\"" >> ~/.bashrc;
+then
+echo "export RAVEROOT=/home/vagrant/miniconda/envs/openradar" >> ~/.bashrc
+echo "export PATH=\"\$PATH:/home/vagrant/miniconda/envs/openradar/rave/bin\"" >> ~/.bashrc;
+echo "export LD_LIBRARY_PATH=\"\$LD_LIBRARY_PATH:/home/vagrant/miniconda/envs/openradar/rave/lib\"" >> ~/.bashrc;
 fi

--- a/provision_scripts/install_baltrad_rave.sh
+++ b/provision_scripts/install_baltrad_rave.sh
@@ -10,7 +10,6 @@ set -x
 #sudo apt-get install -qq libproj-dev
 sudo apt-get install -qq expat
 sudo apt-get install -qq libexpat-dev
-sudo apt-get install -qq libpython2.7-dbg
 
 export LD_LIBRARY_PATH=/opt/baltrad/hlhdf/lib
 
@@ -25,10 +24,10 @@ cd rave
 sed -i -e 's/import jprops/#import jprops/g' Lib/rave_bdb.py
 sed -i -e 's/import jprops/#import jprops/g' Lib/rave_dom_db.py
 sed -i -e 's/from keyczar import keyczar/#from keyczar import keyczar/g' Lib/BaltradFrame.py
-./configure --prefix=/opt/baltrad/rave --with-hlhdf=/opt/baltrad/hlhdf --with-proj=/usr/include,/usr/lib/x86_64-linux-gnu --with-expat=/usr/include,/usr/lib/x86_64-linux-gnu --with-bufr=/opt/baltrad/bbufr --with-numpy=/usr/lib/python2.7/dist-packages/numpy/core/include/numpy/ --with-netcdf=/usr/include,/usr/lib/x86_64-linux-gnu
+./configure --prefix=/opt/baltrad/rave --with-hlhdf=/opt/baltrad/hlhdf --with-proj=/usr/include,/usr/lib/x86_64-linux-gnu --with-expat=/usr/include,/usr/lib/x86_64-linux-gnu --with-numpy=/usr/lib/python3/dist-packages/numpy/core/include/numpy/ --with-netcdf=/usr/include,/usr/lib/x86_64-linux-gnu --enable-py3support
 make
 make test
-make install
+sudo make install
 
 grep -l rave ~/.bashrc
 if [ $? == 1 ] ;

--- a/provision_scripts/install_baltrad_rave_gmap.sh
+++ b/provision_scripts/install_baltrad_rave_gmap.sh
@@ -12,29 +12,17 @@ sudo cp /vagrant/vendor/etc/apache2/apache2.conf /etc/apache2/apache2.conf
 sudo cp /vagrant/vendor/etc/apache2/sites-enabled/000-default.conf /etc/apache2/sites-enabled/000-default.conf
 sudo service apache2 restart
 
-# Seemingly unnecessary dependency: Imaging 1.1.7
-# Because stock pillow in Ubuntu does not support PNG properly.
-cd ~
-if ! [ -d tmp ]; then
-mkdir tmp
-fi
-cd tmp
-wget --no-check-certificate http://git.baltrad.eu/blt_dependencies/Imaging-1.1.7.tar.gz .
-tar xvzf Imaging-1.1.7.tar.gz
-cd Imaging-1.1.7
-sed -i -e 's/#include <freetype\//#include <freetype2\/freetype\//g' _imagingft.c
-sudo cp /vagrant/vendor/setup.py.Imaging-1.1.7-tweaked setup.py
-sudo python setup.py install
+pip3 install Pillow
 
 # install GoogleMapsPlugin from source
 cd ~/tmp
 git clone --depth=1 git://git.baltrad.eu/GoogleMapsPlugin.git
 cd GoogleMapsPlugin/
-python setup.py install --prefix=/opt/baltrad
+sudo python3 setup.py install --prefix=/opt/baltrad
 # HACK the setup.py files need to add the line
 # import distutils.sysconfig
 # The .pth file is not copied because of this, manually create the file
-sudo echo /opt/baltrad/rave_gmap/Lib/ > /usr/lib/python2.7/site-packages/rave_gmap.pth
+sudo echo /opt/baltrad/rave_gmap/Lib/ > /usr/lib/python3/dist-packages/rave_gmap.pth
 
 # Add an amazing case!
 cp /vagrant/vendor/opt/baltrad/rave_gmap/web/smhi-areas.xml /opt/baltrad/rave_gmap/web/.

--- a/provision_scripts/install_baltrad_rave_gmap.sh
+++ b/provision_scripts/install_baltrad_rave_gmap.sh
@@ -4,7 +4,7 @@ set -x
 # Vagrant provision script for installing BALTRAD GoogleMapsPlugin component
 
 # dependencies
-sudo apt-get install -qq libfreetype6-dev
+#sudo apt-get install -qq libfreetype6-dev
 sudo apt-get install -qq apache2
 sudo apt-get install -qq php
 sudo apt-get install -qq libapache2-mod-php
@@ -12,23 +12,28 @@ sudo cp /vagrant/vendor/etc/apache2/apache2.conf /etc/apache2/apache2.conf
 sudo cp /vagrant/vendor/etc/apache2/sites-enabled/000-default.conf /etc/apache2/sites-enabled/000-default.conf
 sudo service apache2 restart
 
-pip3 install Pillow
+source $CONDA_DIR/bin/activate $CONDA_DIR/envs/$RADARENV/ && \
+    conda install -c conda-forge --yes pillow
 
 # install GoogleMapsPlugin from source
 cd ~/tmp
 git clone --depth=1 git://git.baltrad.eu/GoogleMapsPlugin.git
 cd GoogleMapsPlugin/
-sudo python3 setup.py install --prefix=/opt/baltrad
+python setup.py install --prefix=/home/vagrant/miniconda/envs/openradar
+# Replace Google Maps with OpenStreetMap
+cp web/index.html /home/vagrant/miniconda/envs/openradar/rave_gmap/web/.
+rm /home/vagrant/miniconda/envs/openradar/rave_gmap/web/index.php
+
 # HACK the setup.py files need to add the line
 # import distutils.sysconfig
 # The .pth file is not copied because of this, manually create the file
-sudo echo /opt/baltrad/rave_gmap/Lib/ > /usr/lib/python3/dist-packages/rave_gmap.pth
+echo /home/vagrant/miniconda/envs/openradar/rave_gmap/Lib/ > /home/vagrant/miniconda/envs/openradar/lib/python3.6/site-packages/rave_gmap.pth
 
 # Add an amazing case!
-cp /vagrant/vendor/opt/baltrad/rave_gmap/web/smhi-areas.xml /opt/baltrad/rave_gmap/web/.
-cp /vagrant/vendor/opt/baltrad/rave_gmap/web/products.js /opt/baltrad/rave_gmap/web/.
-mkdir /opt/baltrad/rave_gmap/web/data
-cp /vagrant/vendor/opt/baltrad/rave_gmap/web/data/cawkr_gmaps.tgz /opt/baltrad/rave_gmap/web/data/.
-cd /opt/baltrad/rave_gmap/web/data
+cp /vagrant/vendor/opt/baltrad/rave_gmap/web/smhi-areas.xml /home/vagrant/miniconda/envs/openradar/rave_gmap/web/.
+cp /vagrant/vendor/opt/baltrad/rave_gmap/web/products.js /home/vagrant/miniconda/envs/openradar/rave_gmap/web/.
+mkdir /home/vagrant/miniconda/envs/openradar/rave_gmap/web/data
+cp /vagrant/vendor/opt/baltrad/rave_gmap/web/data/cawkr_gmaps.tgz /home/vagrant/miniconda/envs/openradar/rave_gmap/web/data/.
+cd /home/vagrant/miniconda/envs/openradar/rave_gmap/web/data
 tar xzf cawkr_gmaps.tgz
 rm cawkr_gmaps.tgz

--- a/provision_scripts/install_baltrad_wrwp.sh
+++ b/provision_scripts/install_baltrad_wrwp.sh
@@ -3,8 +3,8 @@ set -x
 
 # Vagrant provision script for installing BALTRAD wrwp from source
 
-# install dependencies
-export LD_LIBRARY_PATH=/opt/baltrad/hlhdf/lib:/opt/baltrad/rave/lib
+# Install system dependencies, not conda in this case
+export LD_LIBRARY_PATH=/home/vagrant/miniconda/envs/openradar/lib:/home/vagrant/miniconda/envs/openradar/hlhdf/lib:/home/vagrant/miniconda/envs/openradar/rave/lib
 sudo apt-get install -qq libatlas-base-dev
 sudo apt-get install -qq liblapacke-dev
 
@@ -14,28 +14,27 @@ if ! [ -d tmp ]; then
 mkdir tmp
 fi
 cd tmp
-cd rave
-sudo cp librave/toolbox/*.h /opt/baltrad/rave/include/
 
 # HACK we need .../rave/tmp to exist
-sudo mkdir /opt/baltrad/rave/tmp
-sudo chown vagrant:vagrant /opt/baltrad/rave/tmp
+mkdir /home/vagrant/miniconda/envs/openradar/rave/tmp
+chown vagrant:vagrant /home/vagrant/miniconda/envs/openradar/rave/tmp
 
 # install baltrad_wrwp from source
 cd ~
 cd tmp
 git clone --depth 1 git://git.baltrad.eu/baltrad-wrwp.git
 cd baltrad-wrwp/
-./configure --prefix=/opt/baltrad/baltrad-wrwp --with-rave=/opt/baltrad/rave --with-blas=/usr/lib --with-cblas=/usr/lib --with-lapack=/usr/lib --with-lapacke=/usr/include,/usr/lib
+
+source $CONDA_DIR/bin/activate $CONDA_DIR/envs/$RADARENV/
+
+./configure --prefix=/home/vagrant/miniconda/envs/openradar/baltrad-wrwp --with-rave=/home/vagrant/miniconda/envs/openradar/rave --with-blas=/usr/lib --with-cblas=/usr/lib --with-lapack=/usr/lib --with-lapacke=/usr/include,/usr/lib
 make
 make test
-sudo make install
+make install
 
 grep -l wrwp ~/.bashrc
 if [ $? == 1 ] ;
 then 
-echo "export PATH=\"\$PATH:/opt/baltrad/baltrad-wrwp/bin\"" >> ~/.bashrc;
-echo "export LD_LIBRARY_PATH=\"\$LD_LIBRARY_PATH:/opt/baltrad/baltrad-wrwp/lib\"" >> ~/.bashrc;
+echo "export PATH=\"\$PATH:/home/vagrant/miniconda/envs/openradar/baltrad-wrwp/bin\"" >> ~/.bashrc;
+echo "export LD_LIBRARY_PATH=\"\$LD_LIBRARY_PATH:/home/vagrant/miniconda/envs/openradar/baltrad-wrwp/lib\"" >> ~/.bashrc;
 fi
-echo /opt/baltrad/baltrad-wrwp/share/wrwp/pywrwp/ > baltrad_wrwp.pth
-sudo mv baltrad_wrwp.pth /usr/lib/python3/dist-packages/baltrad_wrwp.pth

--- a/provision_scripts/install_baltrad_wrwp.sh
+++ b/provision_scripts/install_baltrad_wrwp.sh
@@ -19,7 +19,7 @@ sudo cp librave/toolbox/*.h /opt/baltrad/rave/include/
 
 # HACK we need .../rave/tmp to exist
 sudo mkdir /opt/baltrad/rave/tmp
-chown vagrant:vagrant /opt/baltrad/rave/tmp
+sudo chown vagrant:vagrant /opt/baltrad/rave/tmp
 
 # install baltrad_wrwp from source
 cd ~
@@ -29,7 +29,7 @@ cd baltrad-wrwp/
 ./configure --prefix=/opt/baltrad/baltrad-wrwp --with-rave=/opt/baltrad/rave --with-blas=/usr/lib --with-cblas=/usr/lib --with-lapack=/usr/lib --with-lapacke=/usr/include,/usr/lib
 make
 make test
-make install
+sudo make install
 
 grep -l wrwp ~/.bashrc
 if [ $? == 1 ] ;
@@ -37,4 +37,5 @@ then
 echo "export PATH=\"\$PATH:/opt/baltrad/baltrad-wrwp/bin\"" >> ~/.bashrc;
 echo "export LD_LIBRARY_PATH=\"\$LD_LIBRARY_PATH:/opt/baltrad/baltrad-wrwp/lib\"" >> ~/.bashrc;
 fi
-echo /opt/baltrad/baltrad-wrwp/share/wrwp/pywrwp/ > /usr/lib/python2.7/site-packages/baltrad_wrwp.pth
+echo /opt/baltrad/baltrad-wrwp/share/wrwp/pywrwp/ > baltrad_wrwp.pth
+sudo mv baltrad_wrwp.pth /usr/lib/python3/dist-packages/baltrad_wrwp.pth

--- a/provision_scripts/install_pyart.sh
+++ b/provision_scripts/install_pyart.sh
@@ -6,16 +6,16 @@ set -x
 # dependencies
 ##sudo apt-get install -qq libfontconfig1 --> moved to install_common.sh 
 ##sudo apt-get install -qq gfortran               # for Steiner echo-class --> moved to install_common.sh
-sudo apt-get install -qq python-mpltoolkits.basemap
+#sudo apt-get install -qq python-mpltoolkits.basemap
 
 # Install Py-ART version 1.9.1 from source to system Python.
-cd ~
-mkdir tmp
-cd tmp
-wget https://github.com/ARM-DOE/pyart/releases/download/v1.9.1-picasso/arm_pyart-1.9.1.tar.gz
-tar xf arm_pyart-1.9.1.tar.gz
-cd arm_pyart-1.9.1/
-sudo python setup.py install
+#cd ~
+#mkdir tmp
+#cd tmp
+#wget https://github.com/ARM-DOE/pyart/releases/download/v1.9.1-picasso/arm_pyart-1.9.1.tar.gz
+#tar xf arm_pyart-1.9.1.tar.gz
+#cd arm_pyart-1.9.1/
+#sudo $CONDA_DIR/bin/python setup.py install
 
 # and install to conda env
 source $CONDA_DIR/bin/activate $CONDA_DIR/envs/$RADARENV/ && \

--- a/provision_scripts/install_pyart2baltrad_course.sh
+++ b/provision_scripts/install_pyart2baltrad_course.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -x
 cd ~
-git clone --depth=1 https://github.com/jjhelmus/pyart2baltrad.git
+git clone --depth=1 https://github.com/DanielMichelson/pyart2baltrad.git

--- a/provision_scripts/install_pytmatrix.sh
+++ b/provision_scripts/install_pytmatrix.sh
@@ -2,7 +2,7 @@
 set -x
 
 # PyTMatrix install in system Python
-sudo pip install pytmatrix
+#sudo pip install pytmatrix
 
 # PyTMatrix install in conda env
 source $CONDA_DIR/bin/activate $CONDA_DIR/envs/$RADARENV/ && \

--- a/vendor/etc/apache2/apache2.conf
+++ b/vendor/etc/apache2/apache2.conf
@@ -162,7 +162,7 @@ Include ports.conf
 </Directory>
 
 #<Directory /var/www/>
-<Directory /opt/baltrad/rave_gmap/web>
+<Directory /home/vagrant/miniconda/envs/openradar/rave_gmap/web>
 	Options Indexes FollowSymLinks
 	AllowOverride None
 	Require all granted

--- a/vendor/etc/apache2/sites-enabled/000-default.conf
+++ b/vendor/etc/apache2/sites-enabled/000-default.conf
@@ -10,7 +10,7 @@
 
 	ServerAdmin webmaster@localhost
 	#DocumentRoot /var/www/html
-	DocumentRoot /opt/baltrad/rave_gmap/web
+	DocumentRoot /home/vagrant/miniconda/envs/openradar/rave_gmap/web
 	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
 	# error, crit, alert, emerg.
 	# It is also possible to configure the loglevel for particular

--- a/vendor/fix_shebang.sh
+++ b/vendor/fix_shebang.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+###########################################################################
+# Copyright (C) 2012 Swedish Meteorological and Hydrological Institute, SMHI,
+#
+# This file is part of RAVE.
+#
+# RAVE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# RAVE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+# 
+# You should have received a copy of the GNU Lesser General Public License
+# along with RAVE.  If not, see <http://www.gnu.org/licenses/>.
+# ------------------------------------------------------------------------
+# 
+# Fixes the shebang line in the python scripts
+# @file
+# @author Anders Henja (Swedish Meteorological and Hydrological Institute, SMHI)
+# @date 2018-04-01
+############################################################################
+
+if [ $# -ne 3 ]; then
+  echo "Must specify <python binary> <file to be modifed> <full path to installation>"
+  exit 127
+fi
+
+cat $2 | sed -e '1s|\/usr\/bin\/env python|'$1'|' > "$3/$2"
+
+chmod 755 "$3/$2"
+echo "Copied $2 => $3/$2"
+

--- a/vendor/opt/baltrad/rave/Lib/odc_fixIO.py
+++ b/vendor/opt/baltrad/rave/Lib/odc_fixIO.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python
+'''
+Copyright (C) 2012- Swedish Meteorological and Hydrological Institute (SMHI)
+
+This file is part of RAVE.
+
+RAVE is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+RAVE is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with RAVE.  If not, see <http://www.gnu.org/licenses/>.
+'''
+
+## Routines for validating and harmonizing file contents.
+
+## @file
+## @author Daniel Michelson, SMHI
+## @date 2012-11-05
+
+import _raveio
+import odim_source
+from rave_defines import UTF8
+from numpy import *
+
+
+## Validate input file.
+# @param rio RAVE IO object read from file.
+def Validate(rio):
+    # Zero check: do we have a payload?
+    if not rio.object:
+        raise IOError("Failed to read file.")
+
+    # First ODIM violation fix: ODIM_BUFR cannot tell the difference between
+    # a SCAN and a PVOL. ODIM_H5 can.
+    if rio.objectType == _raveio.Rave_ObjectType_PVOL and rio.object.getNumberOfScans() == 1:
+        DATE, TIME = rio.object.date, rio.object.time
+        rio.object = rio.object.getScan(0)
+        rio.object.date, rio.object.time = DATE, TIME
+
+    # Second (potential) ODIM violation: bad or incomplete value of /what/source
+    # Harmonize, because bRopo looks up filter settings based on this attribute.
+    try:
+        odim_source.CheckSource(rio.object)
+        s = odim_source.ODIM_Source(rio.object.source)
+        if not s.nod: raise AttributeError()
+        if not s.wmo:
+            rio.object.source = odim_source.SOURCE[s.nod].encode(UTF8)
+    except:
+        rio.object.source=repair_odim_source(rio.object)
+        s = odim_source.ODIM_Source(rio.object.source)
+
+    # Third issue, not an ODIM violation as such: ODIM_BUFR returns datasets as
+    # float64 arrays, which a massive waste of RAM. Harmonize to uint8.
+    # Note: this is not a problem for the toolbox as such, but it is a problem
+    # for Ropo because Ropo assumes uint8 data.
+    if rio.file_format == _raveio.RaveIO_ODIM_FileFormat_BUFR:
+        ConvertDatasets(rio)
+
+    # Step 4: combination of data and metadata fixes.
+    # In one known instance, a country supplies TH but not DBZH data. bRopo
+    # currently requires DBZH, so in these cases rename TH to DBZH.
+    # Very few countries supply their data violating the ancient GORN "rules"
+    # for nodata and undetect, but it happens, so identify and fix.
+    # Note: this is not a problem for the toolbox as such, but it is a problem
+    # for Ropo because Ropo assumes standard values.
+    # Unfortunately, all data must be checked.
+    # While we're at it, perform a sanity check on the values of 'where/rstart'
+    # and 'where/rscale'. This is an ODIM violation that doesn't need
+    # correcting for ropo, but should be correctly represented for use by
+    # other parts of the toolbox if required.
+    CheckOddsnEnds(rio)
+
+
+## Fix bad WMO numbers, among other things. This is a collection of workarounds.
+# @param obj input object
+# @return string containing correctly-formatted /what/source
+def repair_odim_source(obj):
+    import re
+
+    source = obj.source
+    # France - Falaise
+    if obj.source == 'WMO:07027':
+        return odim_source.SOURCE["frcae"].encode(UTF8)
+    # France - Nancy
+    elif obj.source == 'WMO:07180':
+        return odim_source.SOURCE["frnan"].encode(UTF8)
+    # France - Nimes
+    elif obj.source == 'WMO:07645':
+        return odim_source.SOURCE["frnim"].encode(UTF8)
+    # France - Arcis
+    elif obj.source == 'WMO:07168':
+        return odim_source.SOURCE["frtro"].encode(UTF8)
+    # France - Sembadel
+    elif obj.source == 'WMO:07471':
+        return odim_source.SOURCE["frlep"].encode(UTF8)
+    # Cerceda - Spain
+    elif obj.source[:9] == 'WMO:08007':
+        return odim_source.SOURCE["escor"].encode(UTF8)
+    # Almeria - Spain
+    elif obj.source[:9] == 'WMO:08489':
+        return odim_source.SOURCE["esalm"].encode(UTF8)
+    # Spain - Sierra de Fuentes, a k a Badajoz
+    elif obj.source[:9] == "WMO:08262":
+        return odim_source.SOURCE["esbad"].encode(UTF8)
+    # Spain - Autilla Pino, a k a Valladolid
+    elif obj.source[:9] == "WMO:08262":
+        return odim_source.SOURCE["eslid"].encode(UTF8)
+    # Spain - Aguion, a k a Santander
+    elif obj.source[:9] == "WMO:08019":
+        return odim_source.SOURCE["essan"].encode(UTF8)
+    # Jersey
+    elif obj.source == 'WMO:00897':
+        return odim_source.SOURCE["ukjer"].encode(UTF8)
+    # Keflavik
+    elif obj.source == 'WMO:0,PLC:Keflavik':
+        obj.height = 45.0
+        return odim_source.SOURCE["iskef"].encode(UTF8)
+    # Dublin
+    elif obj.source == 'WMO:03696':
+        return odim_source.SOURCE["iedub"].encode(UTF8)
+    # Essen
+    elif obj.source == 'WMO:10412':
+        return odim_source.SOURCE["deess"].encode(UTF8)
+    # KNMI:
+    elif len(source.split(";")) == 2 or source[:6] == "RAD:NL":
+        #source = re.sub(";", ",", source)  # no longer needed
+        source = re.sub("PLC", "NOD", source)
+        s = odim_source.ODIM_Source(source)
+        return odim_source.SOURCE[s.nod].encode(UTF8)
+    # met.no
+    elif re.search("1438", obj.source):
+        return odim_source.SOURCE["nohgb"].encode(UTF8)
+    elif re.search("1104", obj.source):
+        return odim_source.SOURCE["norst"].encode(UTF8)
+    elif re.search("1405", obj.source):
+        return odim_source.SOURCE["nobml"].encode(UTF8)
+    elif obj.source == 'WMO:01079,NOD:nober,PLC:Berlev\xe5g':
+        return odim_source.SOURCE["nober"].encode(UTF8)
+    # Serbia
+    elif obj.source == "WMO:0,PLC:Samos":
+        return odim_source.SOURCE["rssam"].encode(UTF8)
+    # Iceland
+    elif obj.source == "WMO:0,PLC:Teigsbjarg":
+        return odim_source.SOURCE["istgb"].encode(UTF8)
+
+
+## Manages the conversion of datasets from float64 to uint8.
+# @param rio RAVE I/O object
+def ConvertDatasets(rio):
+    obj = rio.object
+    if rio.objectType == _raveio.Rave_ObjectType_SCAN:
+        dbzh = obj.getParameter("DBZH")
+        ConvertParam(dbzh)
+    else:
+        for i in range(obj.getNumberOfScans()):
+            scan = obj.getScan(i)
+            dbzh = scan.getParameter("DBZH")
+            ConvertParam(dbzh)
+
+
+## Converts 64-bit float to 8-bit uint, with standard scaling
+# @param param dataset containing physical parameter.
+def ConvertParam(param):
+    param.gain =     0.5
+    param.offset = -32.0
+    param.nodata = 255.0
+    param.undetect = 0.0
+    param.convertDataDoubleToUchar()
+
+
+## Convenience function for doing the real work in \ref CheckOddsnEnds
+# @param scan polar scan object
+def CheckScan(scan):
+    if (scan.nbins * scan.rscale / 1000) < scan.rstart:
+        scan.rstart /= 1000.0
+    if scan.rscale < 10.0: scan.rscale *= 1000  # Idiot test
+    if scan.hasParameter("TH") and not scan.hasParameter("DBZH"):
+        dbzh = scan.getParameter("TH")
+        dbzh.quantity = "DBZH"
+        scan.removeParameter("TH")
+        scan.addParameter(dbzh)
+    else:
+        dbzh = scan.getParameter("DBZH")
+    ConvertNodataUndetect(dbzh)
+
+
+## Manages the standardization of selected data and metadata attributes.
+# @param obj input RAVE I/O object.
+def CheckOddsnEnds(rio):
+    obj = rio.object
+    if rio.objectType == _raveio.Rave_ObjectType_SCAN:
+        CheckScan(obj)
+    else:
+        for i in range(obj.getNumberOfScans()):
+            scan = obj.getScan(i)
+            CheckScan(scan)
+
+
+## Checks and converts nodata and undetect to standard values.
+# Required by Ropo, not the toolbox.
+# @param param physical parameter object.
+def ConvertNodataUndetect(param):
+    if param.nodata != 255.0:  # This is extremely unlikely
+        data = param.getData()
+        data = where(equal(data, param.nodata), 255, data)
+        param.nodata = 255.0
+        param.setData(data)
+    if param.undetect != 0.0:  # This is much more likely
+        data = param.getData()
+        data = where(equal(data, param.undetect), 0, data)
+        param.undetect = 0.0
+        param.setData(data)
+
+
+if __name__ == "__main__":
+    print(__doc__)

--- a/vendor/opt/baltrad/rave/Lib/rave_mppool.py
+++ b/vendor/opt/baltrad/rave/Lib/rave_mppool.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+'''
+Copyright (C) 2014- Swedish Meteorological and Hydrological Institute (SMHI)
+
+This file is part of RAVE.
+
+RAVE is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+RAVE is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with RAVE.  If not, see <http://www.gnu.org/licenses/>.
+'''
+
+## Class for creating non-daemonic process pools.
+
+## @file
+## @author Daniel Michelson, SMHI
+## @date 2014-09-30
+
+
+import multiprocessing
+import multiprocessing.pool
+
+
+## Inherit Process
+#  @param Process object
+class NonDaemonProcess(multiprocessing.Process):
+    # make 'daemon' attribute always return False
+    def __init__(self):
+        super(NonDaemonProcess,self).__init__()
+    def _get_daemon(self):
+        return False
+    def _set_daemon(self, value):
+        pass
+    daemon = property(_get_daemon, _set_daemon)
+
+
+## We sub-class multiprocessing.pool.Pool instead of multiprocessing.Pool
+#  because the latter is only a wrapper function, not a proper class.
+# @param Pool with our NonDaemonProcess
+class RavePool(multiprocessing.pool.Pool):
+    def Process(self, *args, **kwds):
+        proc = super(RavePool, self).Process(*args, **kwds)
+
+        class NonDaemonProcess(proc.__class__):
+            """Monkey-patch process to ensure it is never daemonized"""
+            @property
+            def daemon(self):
+                return False
+
+            @daemon.setter
+            def daemon(self, val):
+                pass
+
+        proc.__class__ = NonDaemonProcess
+        return proc
+
+
+if __name__ == "__main__":
+    pass

--- a/vendor/opt/baltrad/rave/Lib/rave_win_colors.py
+++ b/vendor/opt/baltrad/rave/Lib/rave_win_colors.py
@@ -1,0 +1,440 @@
+#!/usr/bin/env python
+# -*- coding: latin-1 -*-
+#
+# $Id: rave_win_colors.py,v 1.1.1.1 2006/07/14 11:31:54 dmichels Exp $
+#
+# Author: Daniel Michelson
+#
+# Copyright (c): Swedish Meteorological and Hydrological Institute
+#                2005-
+#                All rights reserved.
+#
+# $Log: rave_win_colors.py,v $
+# Revision 1.1.1.1  2006/07/14 11:31:54  dmichels
+# Project added under CVS
+#
+#
+"""
+rave_win_colors.py - Color palettes for visualization one way or the other.
+"""
+import string
+from rave_defines import *
+import numpy
+
+#DEFINES
+ZERO = numpy.zeros(256).astype('B')
+HALF = (numpy.zeros(256)+128).astype('B')
+MAX = (numpy.zeros(256)+255).astype('B')
+ASC = numpy.arange(256).astype('B')  # ascending levels
+DESC = numpy.arange(255,-1,-1).astype('B')  # descending levels
+BLACK      = [(  0,  0,  0)]
+DARKBLUE   = [(  0,  0,128)]
+BLUE       = [(  0,  0,255)]
+CYAN       = [(  0,255,255)]
+DARKGREEN  = [(  0,128,  0)]
+GREEN      = [(  0,255,  0)]
+DARKYELLOW = [(128,128,  0)]
+YELLOW     = [(255,255,  0)]
+ORANGE     = [(255,128,  0)]
+DARKRED    = [(128,  0,  0)]
+RED        = [(255,  0,  0)]
+PINK       = [(255,  0,128)]
+MAGENTA    = [(255,  0,255)]
+PUREWHITE  = [(255,255,255)]
+GREY1      = [( 21, 21, 21)]
+GREY2      = [( 42, 42, 42)]
+GREY3      = [( 63, 63, 63)]
+GREY4      = [( 84, 84, 84)]
+GREY5      = [(105,105,105)]
+GREY6      = [(126,126,126)]
+GREY7      = [(147,147,147)]
+GREY8      = [(168,168,168)]
+GREY9      = [(189,189,189)]
+GREY10     = [(210,210,210)]
+GREY11     = [(231,231,231)]
+GREY12     = [(252,252,252)]
+
+
+def get_255_colors(rimg):
+    retdata=numpy.array(rimg.data)
+    if retdata.dtype.char != 'B':
+#    if retdata.typecode() != 'b':  # relic from Numeric
+        MIN = numpy.minimum.reduce(retdata.flat)
+        if MIN < 0:
+            retdata = retdata + abs(MIN)
+        MIN = numpy.minimum.reduce(retdata.flat)
+        MAX = numpy.maximum.reduce(retdata.flat)
+        spread = float(MAX-MIN)
+        retdata = ((1 - ((MAX - retdata) / spread)) * 255).astype('B')
+    return retdata
+
+def GetColours(r, g, b, INTERVAL, half=None):
+    if half != None: half = 128
+    else: half = 255
+    p = []
+    here = 0
+    for i in range(0, half, INTERVAL):
+        p.append((r[here],g[here],b[here]))
+        here = here + INTERVAL
+    return p
+
+def torgb(r,g,b):
+    a = numpy.array([r,g,b], 'B')
+    t = numpy.transpose(a).astype('B').tolist()
+    rgb = []
+    for l in t:
+        #print "L="+`l`
+        #rgb = rgb + l
+        rgb.append(tuple(l))
+    #print "RGB="+`rgb`
+    return rgb
+
+def zero(interval, plus=None):
+    l = len(list(range(0,255,interval)))
+    if plus == None:
+        return numpy.zeros(l, 'B')
+    else:
+        return (numpy.zeros(l)+plus).astype('B')
+
+def zeromax(interval):
+    return list(range(0,255,interval))
+
+def zerohalf(interval):
+    return list(range(0,128,interval))
+
+def halfmax(interval):
+    return list(range(128,255,interval))
+
+def maxhalf(interval):
+    return list(range(255,128,-interval))
+
+def halfzero(interval):
+    return list(range(128,0,-interval))
+
+def maxzero(interval):
+    return list(range(255, 0,-interval))
+
+# even newer continuous dBZ. Compactly incomprehensible!
+def continuous_dbz():
+    p=3*BLACK
+    #p.append(tuple(3 * BLACK))
+    p = p + torgb(zero(8),      zero(8),     zeromax(8)) # blues
+    p = p + torgb(zero(12),     zeromax(12), zero(12,255)) # cyan
+    p = p + torgb(zero(12),     maxhalf(6),  maxzero(12)) # darkgreen
+    p = p + torgb(zero(12),     halfmax(6),  zero(12)) # green
+    p = p + torgb(zerohalf(6),  maxhalf(6),  zero(12)) # dark yellow
+    p = p + torgb(halfmax(6),   halfmax(6),  zero(12)) # yellow
+    p = p + torgb(zero(12,255), maxhalf(6),  zero(12)) # orange
+    p = p + torgb(maxhalf(6),   halfzero(6), zero(12)) # dark red
+    p = p + torgb(halfmax(6),   zero(12),    zero(12)) # red
+    p = p + torgb(zero(12,255), zero(12),    zerohalf(6)) # pink
+    p = p + torgb(zero(12,255), zero(12),    halfmax(6)) # magenta
+    return p+PUREWHITE
+
+def GetIntervals(GAIN, OFFSET):
+    intervals = []
+    for i in range(-30, 91, 10):
+        raw = int(round((i - OFFSET) / GAIN, 0))
+        intervals.append(raw)
+    return intervals
+
+# continuous raw greyscale palette
+def continuous_raw():
+    p = GetColours(ASC, ASC, ASC, 1)
+    return p + PUREWHITE
+
+# discrete raw greyscale
+def discrete_raw(GAIN, OFFSET):
+    firstintervals = GetIntervals(GAIN, OFFSET)
+    intervals = []
+    for i in firstintervals:
+        if 0 <= i < 255: 
+            intervals.append(i)
+    p = BLACK
+    for i in range(len(intervals)):
+        if i == 0:
+            for j in range(intervals[1]):
+                p = p + GREY1
+        elif i == len(intervals)-1:
+            if intervals[i] < 255:
+                for j in range(255-intervals[i]):
+                    p = p + PUREWHITE
+            else:
+                raise ValueError("palette level beyond 255")
+        else:
+            for j in range(intervals[i+1]-intervals[i]):
+                if i == 1: p = p + GREY2
+                elif i == 2: p = p + GREY3
+                elif i == 3: p = p + GREY4
+                elif i == 4: p = p + GREY5
+                elif i == 5: p = p + GREY6
+                elif i == 6: p = p + GREY7
+                elif i == 7: p = p + GREY8
+                elif i == 8: p = p + GREY9
+                elif i == 9: p = p + GREY10
+                elif i == 10: p = p + GREY11
+                elif i == 11: p = p + GREY12
+    return p
+
+# discrete dBZ. Requires linear transform coefficients.
+def disc_dbz(GAIN, OFFSET):
+    firstintervals = GetIntervals(GAIN, OFFSET)
+    intervals = []
+    for i in firstintervals:
+        if 0 <= i < 255: 
+            intervals.append(i)
+    p = BLACK
+    for i in range(len(intervals)):
+        if i == 0:
+            for j in range(intervals[1]):
+                p = p + DARKBLUE
+        elif i == len(intervals)-1:
+            if intervals[i] < 255:
+                for j in range(255-intervals[i]):
+                    p = p + PUREWHITE
+            else:
+                raise ValueError("palette level beyond 255")
+        else:
+            for j in range(intervals[i+1]-intervals[i]):
+                if i == 1: p = p + BLUE
+                elif i == 2: p = p + CYAN
+                elif i == 3: p = p + DARKGREEN
+                elif i == 4: p = p + GREEN
+                elif i == 5: p = p + DARKYELLOW
+                elif i == 6: p = p + YELLOW
+                elif i == 7: p = p + ORANGE
+                elif i == 8: p = p + DARKRED
+                elif i == 9: p = p + RED
+                elif i == 10: p = p + PINK
+                elif i == 11: p = p + MAGENTA
+    return p
+
+
+# discrete m/s palette, tailored to Swedish linear transform coefficients.
+# t is towards, a is away. Assumes t is negative.
+def discrete_ms():
+    t6 = 21 * DARKBLUE   # 1-21,    -40-48
+    t5 = 21 * BLUE       # 22-42,   -32-40
+    t4 = 22 * CYAN       # 43-64,   -24-32
+    t3 = 21 * DARKGREEN  # 65-85,   -16-24
+    t2 = 21 * GREEN      # 86-106,  - 8-16
+    t1 = 18 * DARKYELLOW # 107-124, - 1.5-8
+    z  =  7 * PUREWHITE  # 125-131, +- 1.5
+    a1 = 18 * YELLOW     # 132-149,   1.5-8
+    a2 = 21 * ORANGE     # 150-170,   8-16
+    a3 = 21 * DARKRED    # 171-191,  16-24
+    a4 = 22 * RED        # 192-213,  24-32
+    a5 = 21 * PINK       # 214-234,  32-40
+    a6 = 20 * MAGENTA    # 235-254,  40-48+
+    return BLACK+t6+t5+t4+t3+t2+t1+z+a1+a2+a3+a4+a5+a6+PUREWHITE
+
+# continuous m/s palette, modelled after continuous_dbz. Not very pretty...
+def continuous_ms():
+    p = continuous_dbz()
+    #p[126*3:130*3] = 4 * PUREWHITE
+    p[126:130]=4*PUREWHITE
+    return p
+
+# discrete ff_dev.
+def disc_ff_dev():
+    return BLACK+41*BLUE+42*CYAN+42*GREEN+42*YELLOW+42*RED+45*MAGENTA+PUREWHITE
+
+def discrete_mm():
+    return BLACK + 20*DARKBLUE + 20*BLUE + 20*CYAN + 20*DARKGREEN + \
+           20*GREEN + 20*DARKYELLOW + 20*YELLOW + 20*ORANGE + 20*DARKRED + \
+           20*RED + 20*MAGENTA + 35*PUREWHITE
+
+
+class color_map:
+    _color_maps={}
+    def __init__(self,ltype,colors=None,descr=None):
+        if not ltype in self._color_maps:
+            self.icolor=colors
+            self.idescr=descr
+            self._color_maps[ltype]=self
+            self._ltype=ltype
+
+    def color(self,**kw):
+        return self.icolor
+
+    def description(self,**kw):
+        if self.idescr!=None:
+            return self.idescr
+
+        intervals=[]
+        OFFSET=kw["OFFSET"]
+        GAIN=kw["GAIN"]
+
+        # radial wind velocity gets special treatment
+        if GAIN == 0.375 and int(OFFSET) == -48:
+            for i in range(-48,49,8):
+                raw = int(round((i - OFFSET) / GAIN, 0))
+                if raw<260:
+                    intervals.append((raw,string.rjust(repr(i),4)))
+        else:
+            for i in range(-30, 91, 10):
+                raw = int(round((i - OFFSET) / GAIN, 0))
+                if raw<256:
+                    intervals.append((raw,string.rjust(repr(i),4)))
+        return intervals
+
+    def options(self,**kw):
+        return {}
+
+class slope_map(color_map):
+    _slope_ord_map=[]
+
+    def __init__(self,ltype):
+        color_map.__init__(*(self,ltype))
+
+    def color(self,**kw):
+        intervals=[]
+        OFFSET=kw["OFFSET"]
+        GAIN=kw["GAIN"]
+
+        stup=(self._ltype,OFFSET,GAIN)
+        for i in self._slope_ord_map:
+            if stup==i[0]:
+                return i[1]
+
+        intervals=self._get_interval(GAIN,OFFSET)
+
+        self._slope_ord_map.append((stup,intervals))
+
+        return intervals
+
+    def _get_interval(self,GAIN,OFFSET):
+        raise AttributeError("Calling _get_interval in baseclass slope_map")
+
+
+class discrete_raw_slope(slope_map):
+    def __init__(self):
+        slope_map.__init__(*(self,"discrete_raw"))
+
+    def _get_interval(self,GAIN,OFFSET):
+        return discrete_raw(GAIN,OFFSET)
+
+class discrete_dbz_slope(slope_map):
+    def __init__(self):
+        slope_map.__init__(*(self,"discrete_dbz"))
+
+    def _get_interval(self,GAIN,OFFSET):
+        return disc_dbz(GAIN,OFFSET)
+
+class wind_profile(color_map):
+    def __init__(self):
+        color_map.__init__(*(self,"wind_profile",disc_ff_dev()))
+        self.init_description()
+
+    def init_description(self):
+        self.mydescr=[]
+        #j=0
+        #for i in range(0,300,50):
+        #    self.mydescr.append((i,`i/100.0`))
+        self.mydescr.append((21,'0 kts'))
+        self.mydescr.append((63,'1'))
+        self.mydescr.append((105,'2'))
+        self.mydescr.append((147,'3'))
+        self.mydescr.append((189,'4'))
+        self.mydescr.append((231,'5 kts'))
+
+    def description(self,**kw):
+        return self.mydescr
+
+    def options(self,**kw):
+        return {'anchor':'w'}
+
+class radial_wind_velocity(color_map):
+    def __init__(self):
+        color_map.__init__(*(self,"radial_wind_velocity",discrete_ms()))
+        self.init_description()
+
+    def init_description(self):
+        self.mydescr=[]
+        self.mydescr.append((1,'towards'))
+        self.mydescr.append((21,'40'))
+        self.mydescr.append((42,'32'))
+        self.mydescr.append((64,'24'))
+        self.mydescr.append((85,'16'))
+        self.mydescr.append((106,'8'))
+        self.mydescr.append((127,'0'))
+        self.mydescr.append((150,'8'))
+        self.mydescr.append((171,'16'))
+        self.mydescr.append((192,'24'))
+        self.mydescr.append((214,'32'))
+        self.mydescr.append((235,'40'))
+        self.mydescr.append((254,'away'))
+
+    def description(self,**kw):
+        return self.mydescr
+
+    def options(self,**kw):
+        return {'anchor':'w'}
+
+class accumulated_mm(color_map):
+    def __init__(self):
+        color_map.__init__(*(self,"accumulated_mm",discrete_mm()))
+        self.init_description()
+
+    def init_description(self):
+        self.mydescr=[]
+        self.mydescr.append((1,  '    0.1'))
+        self.mydescr.append((21, '    0.25'))
+        self.mydescr.append((41, '    0.5'))
+        self.mydescr.append((61, '    1'))
+        self.mydescr.append((81, '    2'))
+        self.mydescr.append((101,'    4'))
+        self.mydescr.append((121,'    8'))
+        self.mydescr.append((141,'   16'))
+        self.mydescr.append((161,'   32'))
+        self.mydescr.append((181,'   64'))
+        self.mydescr.append((201,'  128'))
+        self.mydescr.append((221,'  250'))
+        self.mydescr.append((254,'> 250'))
+
+    def description(self,**kw):
+        return self.mydescr
+
+    def options(self,**kw):
+        return {'anchor':'w'}
+
+def get_colors(type):
+    return color_map._color_maps[type]
+
+#Register them
+color_map("continuous_dbz",continuous_dbz())
+color_map("continuous_raw",continuous_raw())
+discrete_raw_slope()
+discrete_dbz_slope()
+color_map("continuous_ms",continuous_ms())
+color_map("discrete_ms",discrete_ms())
+
+wind_profile()
+radial_wind_velocity()
+accumulated_mm()
+
+
+# Helper function to translate a list of 256 3-tuples to one 768 list.
+def to768(p):
+    out = []
+    for i in p:
+        out = out + list(i)
+    return out
+
+# 768-length lists for use with PIL and/or rave_ql.py
+continuous_dBZ = to768(continuous_dbz())
+continuous_RAW = to768(continuous_raw())
+discrete_dBZ_SMHI = to768(disc_dbz(0.4, -30))
+discrete_dBZ_BLT = to768(disc_dbz(GAIN, OFFSET))
+discrete_RAW_SMHI = to768(discrete_raw(0.4, -30))
+discrete_RAW_BLT = to768(discrete_raw(GAIN, OFFSET))
+discrete_MS = to768(discrete_ms())
+continuous_MS = to768(continuous_ms())
+discrete_ff_dev = to768(disc_ff_dev())
+
+
+
+__all__ = ['__file__']
+
+if __name__ == "__main__":
+    print(__doc__)


### PR DESCRIPTION
The migration has been completed in two steps:
1. Migrate to system Python3
2. Migrate to conda and its Python3

The BALTRAD notebooks have been updated, as have the interoperability notebooks with Py-ART.
It was discovered that a few BALTRAD files needed work. The fixes included here are expected to he phased out in subsequent versions of this project.

Along the way, it was found that radx needs attention, possibly by replacing it with an LROSE install or pre-built binary package.