### PR TITLE
FIX: tmp directory

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,6 +23,8 @@ Vagrant.configure("2") do |config|
   config.vm.network "forwarded_port", guest: 8888, host: 8888
   # Forward the httpd port
   config.vm.network "forwarded_port", guest: 80, host: 8080
+  # Forward SSH port to not conflict with Trusty
+  config.vm.network :forwarded_port, guest: 22, host: 2223, id: 'ssh'
   
   config.ssh.forward_agent = true
   

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,8 +23,8 @@ Vagrant.configure("2") do |config|
   config.vm.network "forwarded_port", guest: 8888, host: 8888
   # Forward the httpd port
   config.vm.network "forwarded_port", guest: 80, host: 8080
-  # Forward SSH port to not conflict with Trusty
-  config.vm.network :forwarded_port, guest: 22, host: 2223, id: 'ssh'
+  # Forward SSH port. Can be changed if you run multiple VMs
+  config.vm.network :forwarded_port, guest: 22, host: 2222, id: 'ssh'
   
   config.ssh.forward_agent = true
   

--- a/provision_scripts/install_baltrad_beamb.sh
+++ b/provision_scripts/install_baltrad_beamb.sh
@@ -8,7 +8,7 @@ export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$CONDA_PREFIX/hlhdf/lib:$CONDA_PREFIX/r
 
 # install beamb from source
 cd ~
-if ! [[ -d tmp ]]; then
+if [ ! -d tmp ]; then
     mkdir tmp
 fi
 cd tmp

--- a/provision_scripts/install_baltrad_bropo.sh
+++ b/provision_scripts/install_baltrad_bropo.sh
@@ -8,7 +8,7 @@ export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$CONDA_PREFIX/hlhdf/lib:$CONDA_PREFIX/r
 
 # install bropo from source
 cd ~
-if ! [[ -d tmp ]]; then
+if [ ! -d tmp ]; then
     mkdir tmp
 fi
 cd tmp

--- a/provision_scripts/install_baltrad_hlhdf.sh
+++ b/provision_scripts/install_baltrad_hlhdf.sh
@@ -5,7 +5,7 @@ set -x
 
 # Install hlhdf from source into conda env
 cd ~
-if ![[ -d tmp ]]; then
+if [ ! -d tmp ]; then
     mkdir tmp
     fi
 cd tmp

--- a/provision_scripts/install_baltrad_rave.sh
+++ b/provision_scripts/install_baltrad_rave.sh
@@ -7,7 +7,7 @@ export LD_LIBRARY_PATH=$CONDA_PREFIX/hlhdf/lib
 
 # Install RAVE from source
 cd ~
-if ! [[ -d tmp ]]; then
+if [ ! -d tmp ]; then
     mkdir tmp
 fi
 cd tmp

--- a/provision_scripts/install_baltrad_wrwp.sh
+++ b/provision_scripts/install_baltrad_wrwp.sh
@@ -10,7 +10,7 @@ sudo apt-get install -qq liblapacke-dev
 
 # HACK some include files are not copied when RAVE is installed
 cd ~
-if ![[ -d tmp ]]; then
+if [ ! -d tmp ]; then
     mkdir tmp
 fi
 cd tmp


### PR DESCRIPTION
Checking ~/tmp when using it to build software seemed like poor syntax, so this is corrected here.